### PR TITLE
ディレクトリ数が合わないパターンがあったため修正

### DIFF
--- a/internal/counter.go
+++ b/internal/counter.go
@@ -20,8 +20,8 @@ func newCounter() *counter {
 
 func (c *counter) count(path string) {
 	dir, file := filepath.Split(path)
-	splited := strings.Split(dir, "/")
 	if len(dir) > 0 {
+		splited := strings.Split(dir, "/")
 		for i := range splited {
 			c.dirs[filepath.Join(splited[:i+1]...)] = struct{}{}
 		}

--- a/internal/counter.go
+++ b/internal/counter.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 type counter struct {
@@ -19,8 +20,11 @@ func newCounter() *counter {
 
 func (c *counter) count(path string) {
 	dir, file := filepath.Split(path)
+	splited := strings.Split(dir, "/")
 	if len(dir) > 0 {
-		c.dirs[dir] = struct{}{}
+		for i := range splited {
+			c.dirs[filepath.Join(splited[:i+1]...)] = struct{}{}
+		}
 	}
 	if len(file) > 0 {
 		c.files[path] = struct{}{}

--- a/internal/counter_test.go
+++ b/internal/counter_test.go
@@ -26,6 +26,14 @@ func TestCounter_Summary(t *testing.T) {
 			},
 			want: "5 directories, 7 files",
 		},
+		{
+			name: "pattern2",
+			paths: []string{
+				"skillset-visualizer/terraform/state/default.tfstate",
+				"standard/module/structure/default.tfstate",
+			},
+			want: "6 directories, 2 files",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/counter_test.go
+++ b/internal/counter_test.go
@@ -5,26 +5,43 @@ import (
 )
 
 func TestCounter_Summary(t *testing.T) {
-	paths := []string{
-		"empty_directory/",
-		"a.txt",
-		"a.tgz",
-		"source/a.tgz",
-		"source/b.tgz",
-		"source/c.tgz",
-		"tmp_directory/",
-		"tmp_directory/a.png",
-		"tmp_directory/empty_directory/",
-		"tmp_directory/source/a.tgz",
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{
+			name: "pattern1",
+			paths: []string{
+				"empty_directory/",
+				"a.txt",
+				"a.tgz",
+				"source/a.tgz",
+				"source/b.tgz",
+				"source/c.tgz",
+				"tmp_directory/",
+				"tmp_directory/a.png",
+				"tmp_directory/empty_directory/",
+				"tmp_directory/source/a.tgz",
+			},
+			want: "5 directories, 7 files",
+		},
 	}
-	want := "5 directories, 7 files"
-	c := newCounter()
-	for _, p := range paths {
-		c.count(p)
-	}
-	got := c.summary()
 
-	if got != want {
-		t.Errorf("\ngot: \n%s\nwant: \n%s", got, want)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newCounter()
+			for _, p := range tt.paths {
+				c.count(p)
+			}
+			got := c.summary()
+
+			if got != tt.want {
+				t.Errorf("\ngot: \n%s\nwant: \n%s", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/gcstree.go
+++ b/internal/gcstree.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -52,9 +51,6 @@ func (g *GCSTree) GetObjectList(ctx context.Context) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		log.Println("Debug:")
-		fmt.Println(attrs.Name)
 		g.counter.count(attrs.Name)
 		names = append(names, attrs.Name)
 	}

--- a/internal/gcstree.go
+++ b/internal/gcstree.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -51,6 +52,9 @@ func (g *GCSTree) GetObjectList(ctx context.Context) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		log.Println("Debug:")
+		fmt.Println(attrs.Name)
 		g.counter.count(attrs.Name)
 		names = append(names, attrs.Name)
 	}


### PR DESCRIPTION
@owlinux1000 

すみません、バグを埋め込んでしまってたので修正PRです🙇

### 事象
```console
~/github.com/ddddddO/gtree
02:21:25 > gcstree tf-state-work1111
tf-state-work1111
├── skillset-visualizer
│   └── terraform
│       └── state
│           └── default.tfstate
└── standard
    └── module
        └── structure
            └── default.tfstate

2 directories, 2 files
```

↑のようなバケット構成で試したのですが、サマリで `2 directories` になってしまってました...（本来は、`6 directories` が意図する結果）

gcstree.go内で、以下のようにprint debugすると、

```go
	it := bkt.Objects(ctx, query)
	for {
		attrs, err := it.Next()
		if err == iterator.Done {
			break
		}
		if err != nil {
			return nil, err
		}

		log.Println("Debug:")           <- 追加
		fmt.Println(attrs.Name)       <- 追加

		g.counter.count(attrs.Name)
		names = append(names, attrs.Name)
	}
```

以下の結果でした
```console
2023/10/01 02:55:50 Debug:
skillset-visualizer/terraform/state/default.tfstate
2023/10/01 02:55:50 Debug:
standard/module/structure/default.tfstate
```

バグ修正前のcounterの実装ですと、
- skillset-visualizer/terraform/state/
- standard/module/structure/

の2ディレクトリのみをディレクトリとしてカウントするため、それ以外のディレクトリもカウントするようにしました！

申し訳ないのですが、もう一度取り込んでいただけると...🔥🙇🔥
